### PR TITLE
Stability update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: cmfilter
 Type: Package
 Title: Coordinate-Wise Mediation Filter
-Version: 0.9.3
-Date: 2020-05-06
+Version: 0.9.4
+Date: 2021-11-20
 Author: Erik-Jan van Kesteren <e.vankesteren1@uu.nl>
 Maintainer: Erik-Jan van Kesteren <e.vankesteren1@uu.nl>
 Description: Functions to discover, plot, and select multiple mediators 
@@ -12,7 +12,7 @@ Description: Functions to discover, plot, and select multiple mediators
 License: MIT + file LICENCE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Depends: R (>= 2.10)
 Imports: Matrix,
     sparseMVN,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // arma_cmf
 arma::vec arma_cmf(arma::vec& x, arma::mat& M, arma::vec& y, int& maxIter, int& stableLag, double& critval, int& decfun, int& nCores, int& nStarts, bool& pb);
 RcppExport SEXP _cmfilter_arma_cmf(SEXP xSEXP, SEXP MSEXP, SEXP ySEXP, SEXP maxIterSEXP, SEXP stableLagSEXP, SEXP critvalSEXP, SEXP decfunSEXP, SEXP nCoresSEXP, SEXP nStartsSEXP, SEXP pbSEXP) {

--- a/src/cmfast.cpp
+++ b/src/cmfast.cpp
@@ -138,12 +138,11 @@ arma::uvec cmfastep(arma::vec & x, arma::mat & M, arma::vec & y,
       arma::uvec fcopy = f;                        // create copy of filter
       fcopy(idx)       = 0;                        // without current M
       
-      arma::mat Mx   = getcols(M, fcopy);          // model matrix
-      arma::mat MtM  = Mx.t() * Mx;                // crossprod
-      //arma::mat icp  = arma::inv_sympd(MtM);        // inverse crossprod matrix
+      arma::mat Mx   = getcols(M, fcopy);                                             // model matrix
+      arma::mat MtM  = Mx.t() * Mx;                                                   // crossprod
       arma::mat H    = Mx * arma::solve(MtM, Mx.t(), arma::solve_opts::likely_sympd); // hat matrix
-      r_x            = x - H * x;                  // residual of x
-      r_y            = y - H * y;                  // residual of y
+      r_x            = x - H * x;                                                     // residual of x
+      r_y            = y - H * y;                                                     // residual of y
     }
     
     // test for 

--- a/src/cmfast.cpp
+++ b/src/cmfast.cpp
@@ -140,8 +140,8 @@ arma::uvec cmfastep(arma::vec & x, arma::mat & M, arma::vec & y,
       
       arma::mat Mx   = getcols(M, fcopy);          // model matrix
       arma::mat MtM  = Mx.t() * Mx;                // crossprod
-      arma::mat icp  = arma::inv_sympd(MtM);       // inverse crossprod matrix
-      arma::mat H    = Mx * icp * Mx.t();          // hat matrix
+      //arma::mat icp  = arma::inv_sympd(MtM);        // inverse crossprod matrix
+      arma::mat H    = Mx * arma::solve(MtM, Mx.t(), arma::solve_opts::likely_sympd); // hat matrix
       r_x            = x - H * x;                  // residual of x
       r_y            = y - H * y;                  // residual of y
     }

--- a/tests/testthat/test_01_cpp_backend.R
+++ b/tests/testthat/test_01_cpp_backend.R
@@ -94,7 +94,16 @@ test_that("Adding method works", {
   res3 <- res1 + res2
   expect_equal(res3$selectionRate, (res1$selectionRate + res2$selectionRate)/2)
 })
-
+test_that("CMF works with collinearity", {
+  o <- capture.output(res <<- cmf(
+    cbind(d, d[,3]*0.5), 
+    nStarts = 400,
+    decisionFunction = "prodcoef",
+    nCores = 2,
+    pb = FALSE
+  ), type = "message")
+  expect(inherits(res, "cmf"), "Result is not of class CMF")
+})
 
 context("CPP backend Causal Steps")
 test_that("Single-core csteps cmf works", {
@@ -151,4 +160,14 @@ test_that("Adding method works", {
   res2 <- res
   res3 <- res1 + res2
   expect_equal(res3$selectionRate, (res1$selectionRate + res2$selectionRate)/2)
+})
+test_that("CMF works with collinearity", {
+  o <- capture.output(res <<- cmf(
+    cbind(d, d[,3]*0.5), 
+    nStarts = 400,
+    decisionFunction = "causalsteps",
+    nCores = 2,
+    pb = FALSE
+  ), type = "message")
+  expect(inherits(res, "cmf"), "Result is not of class CMF")
 })


### PR DESCRIPTION
This update improves the stability of the C++ backend of `cmfilter` when the covariance matrix of the mediators is (nearly) singular. An approximate solution will be used (with warnings!) if this is the case.

Solves #5 and #6. 